### PR TITLE
Add base_path to S3 snapshots

### DIFF
--- a/manifests/snapshot.pp
+++ b/manifests/snapshot.pp
@@ -50,7 +50,7 @@ class elasticsearch::snapshot(
   if ($type == 'fs') {
     $settings = "{\"location\": \"${location}\",\"compress\": true}"
   } elsif ($type == 's3') {
-    if ($base_path != '') {
+    if ($base_path) {
       $settings = "{\"bucket\": \"${bucket}\",\"region\": \"${region}\",\"base_path\": \"${base_path}\"}"
     } else
       $settings = "{\"bucket\": \"${bucket}\",\"region\": \"${region}\"}"

--- a/manifests/snapshot.pp
+++ b/manifests/snapshot.pp
@@ -37,6 +37,7 @@ class elasticsearch::snapshot(
   $location         = undef,
   $bucket           = undef,
   $region           = undef,
+  $base_path        = undef,
   $script_path      = $elasticsearch::params::snapshot_script_path,
   $cronjob          = false,
   $cron_starthour   = $elasticsearch::params::cron_starthour,
@@ -49,7 +50,11 @@ class elasticsearch::snapshot(
   if ($type == 'fs') {
     $settings = "{\"location\": \"${location}\",\"compress\": true}"
   } elsif ($type == 's3') {
-    $settings = "{\"bucket\": \"${bucket}\",\"region\": \"${region}\"}"
+    if ($base_path != '') {
+      $settings = "{\"bucket\": \"${bucket}\",\"region\": \"${region}\",\"base_path\": \"${base_path}\"}"
+    } else
+      $settings = "{\"bucket\": \"${bucket}\",\"region\": \"${region}\"}"
+    }
   }
 
   exec { 'Add snapshot to elasticsearch':


### PR DESCRIPTION
In ES < 2.0 the `repositories.s3.base_path` option in `elasticsearch.yaml` is not supported, so `base_path` needs to be explicitly set in the snapshot.