### PR TITLE
Rename module 'elasticsearch' to 'oldelasticsearch'

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -91,7 +91,7 @@ class oldelasticsearch::config {
         $group = $oldelasticsearch::elasticsearch_group
         $pid_dir = $oldelasticsearch::params::pid_dir
 
-        file { '/usr/lib/tmpfiles.d/oldelasticsearch.conf':
+        file { '/usr/lib/tmpfiles.d/elasticsearch.conf':
           ensure  => 'file',
           content => template("${module_name}/usr/lib/tmpfiles.d/elasticsearch.conf.erb"),
           owner   => 'root',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,4 +1,4 @@
-# == Class: elasticsearch::config
+# == Class: oldelasticsearch::config
 #
 # This class exists to coordinate all configuration related actions,
 # functionality and logical units in a central place.
@@ -12,7 +12,7 @@
 # === Examples
 #
 # This class may be imported by other classes to use its functionality:
-#   class { 'elasticsearch::config': }
+#   class { 'oldelasticsearch::config': }
 #
 # It is not intended to be used directly by external resources like node
 # definitions or other modules.
@@ -22,13 +22,13 @@
 #
 # * Richard Pijnenburg <mailto:richard.pijnenburg@elasticsearch.com>
 #
-class elasticsearch::config {
+class oldelasticsearch::config {
 
   #### Configuration
 
   File {
-    owner => $elasticsearch::elasticsearch_user,
-    group => $elasticsearch::elasticsearch_group,
+    owner => $oldelasticsearch::elasticsearch_user,
+    group => $oldelasticsearch::elasticsearch_group,
   }
 
   Exec {
@@ -36,62 +36,62 @@ class elasticsearch::config {
     cwd  => '/',
   }
 
-  if ( $elasticsearch::ensure == 'present' ) {
+  if ( $oldelasticsearch::ensure == 'present' ) {
 
-    $notify_service = $elasticsearch::restart_on_change ? {
-      true  => Class['elasticsearch::service'],
+    $notify_service = $oldelasticsearch::restart_on_change ? {
+      true  => Class['oldelasticsearch::service'],
       false => undef,
     }
 
-    file { $elasticsearch::configdir:
+    file { $oldelasticsearch::configdir:
       ensure => directory,
       mode   => '0644',
     }
 
-    file { $elasticsearch::params::logdir:
+    file { $oldelasticsearch::params::logdir:
       ensure  => 'directory',
       group   => undef,
       mode    => '0644',
       recurse => true,
     }
 
-    file { $elasticsearch::params::homedir:
+    file { $oldelasticsearch::params::homedir:
       ensure  => 'directory',
     }
 
-    file { "${elasticsearch::params::homedir}/bin":
+    file { "${oldelasticsearch::params::homedir}/bin":
       ensure  => 'directory',
       recurse => true,
       mode    => '0755',
     }
 
-    file { $elasticsearch::plugindir:
+    file { $oldelasticsearch::plugindir:
       ensure  => 'directory',
       recurse => true,
     }
 
-    file { $elasticsearch::datadir:
+    file { $oldelasticsearch::datadir:
       ensure  => 'directory',
     }
 
-    file { "${elasticsearch::homedir}/lib":
+    file { "${oldelasticsearch::homedir}/lib":
       ensure  => 'directory',
       recurse => true,
     }
 
-    if $elasticsearch::params::pid_dir {
-      file { $elasticsearch::params::pid_dir:
+    if $oldelasticsearch::params::pid_dir {
+      file { $oldelasticsearch::params::pid_dir:
         ensure  => 'directory',
         group   => undef,
         recurse => true,
       }
 
-      if ($elasticsearch::service_providers == 'systemd') {
-        $user = $elasticsearch::elasticsearch_user
-        $group = $elasticsearch::elasticsearch_group
-        $pid_dir = $elasticsearch::params::pid_dir
+      if ($oldelasticsearch::service_providers == 'systemd') {
+        $user = $oldelasticsearch::elasticsearch_user
+        $group = $oldelasticsearch::elasticsearch_group
+        $pid_dir = $oldelasticsearch::params::pid_dir
 
-        file { '/usr/lib/tmpfiles.d/elasticsearch.conf':
+        file { '/usr/lib/tmpfiles.d/oldelasticsearch.conf':
           ensure  => 'file',
           content => template("${module_name}/usr/lib/tmpfiles.d/elasticsearch.conf.erb"),
           owner   => 'root',
@@ -100,12 +100,12 @@ class elasticsearch::config {
       }
     }
 
-    file { "${elasticsearch::params::homedir}/templates_import":
+    file { "${oldelasticsearch::params::homedir}/templates_import":
       ensure => 'directory',
       mode   => '0644',
     }
 
-    file { "${elasticsearch::params::homedir}/scripts":
+    file { "${oldelasticsearch::params::homedir}/scripts":
       ensure => 'directory',
       mode   => '0644',
     }
@@ -118,9 +118,9 @@ class elasticsearch::config {
       ensure => 'absent',
     }
 
-    $new_init_defaults = { 'CONF_DIR' => $elasticsearch::configdir }
-    augeas { "${elasticsearch::params::defaults_location}/elasticsearch":
-      incl    => "${elasticsearch::params::defaults_location}/elasticsearch",
+    $new_init_defaults = { 'CONF_DIR' => $oldelasticsearch::configdir }
+    augeas { "${oldelasticsearch::params::defaults_location}/elasticsearch":
+      incl    => "${oldelasticsearch::params::defaults_location}/elasticsearch",
       lens    => 'Shellvars.lns',
       changes => template("${module_name}/etc/sysconfig/defaults.erb"),
     }
@@ -132,7 +132,7 @@ class elasticsearch::config {
       ensure => 'absent',
     }
 
-  } elsif ( $elasticsearch::ensure == 'absent' ) {
+  } elsif ( $oldelasticsearch::ensure == 'absent' ) {
     # don't remove anything for now
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,4 +1,4 @@
-# == Class: elasticsearch
+# == Class: oldelasticsearch
 #
 # This class is able to install or remove elasticsearch on a node.
 # It manages the status of the related service.
@@ -174,22 +174,22 @@
 #   package upgrades.
 #   Defaults to: true
 #
-# The default values for the parameters are set in elasticsearch::params. Have
+# The default values for the parameters are set in oldelasticsearch::params. Have
 # a look at the corresponding <tt>params.pp</tt> manifest file if you need more
 # technical information about them.
 #
 # === Examples
 #
 # * Installation, make sure service is running and will be started at boot time:
-#     class { 'elasticsearch': }
+#     class { 'oldelasticsearch': }
 #
 # * Removal/decommissioning:
-#     class { 'elasticsearch':
+#     class { 'oldelasticsearch':
 #       ensure => 'absent',
 #     }
 #
 # * Install everything but disable service(s) afterwards
-#     class { 'elasticsearch':
+#     class { 'oldelasticsearch':
 #       status => 'disabled',
 #     }
 #
@@ -198,32 +198,32 @@
 #
 # * Richard Pijnenburg <mailto:richard.pijnenburg@elasticsearch.com>
 #
-class elasticsearch(
-  $ensure                = $elasticsearch::params::ensure,
-  $status                = $elasticsearch::params::status,
-  $restart_on_change     = $elasticsearch::params::restart_on_change,
-  $autoupgrade           = $elasticsearch::params::autoupgrade,
+class oldelasticsearch(
+  $ensure                = $oldelasticsearch::params::ensure,
+  $status                = $oldelasticsearch::params::status,
+  $restart_on_change     = $oldelasticsearch::params::restart_on_change,
+  $autoupgrade           = $oldelasticsearch::params::autoupgrade,
   $version               = false,
   $package_provider      = 'package',
   $package_url           = undef,
-  $package_dir           = $elasticsearch::params::package_dir,
-  $package_name          = $elasticsearch::params::package,
+  $package_dir           = $oldelasticsearch::params::package_dir,
+  $package_name          = $oldelasticsearch::params::package,
   $package_pin           = true,
-  $purge_package_dir     = $elasticsearch::params::purge_package_dir,
-  $package_dl_timeout    = $elasticsearch::params::package_dl_timeout,
+  $purge_package_dir     = $oldelasticsearch::params::purge_package_dir,
+  $package_dl_timeout    = $oldelasticsearch::params::package_dl_timeout,
   $proxy_url             = undef,
-  $elasticsearch_user    = $elasticsearch::params::elasticsearch_user,
-  $elasticsearch_group   = $elasticsearch::params::elasticsearch_group,
-  $configdir             = $elasticsearch::params::configdir,
-  $purge_configdir       = $elasticsearch::params::purge_configdir,
+  $elasticsearch_user    = $oldelasticsearch::params::elasticsearch_user,
+  $elasticsearch_group   = $oldelasticsearch::params::elasticsearch_group,
+  $configdir             = $oldelasticsearch::params::configdir,
+  $purge_configdir       = $oldelasticsearch::params::purge_configdir,
   $service_provider      = 'init',
   $init_defaults         = undef,
   $init_defaults_file    = undef,
   $init_template         = undef,
   $config                = undef,
-  $datadir               = $elasticsearch::params::datadir,
-  $plugindir             = $elasticsearch::params::plugindir,
-  $plugintool            = $elasticsearch::params::plugintool,
+  $datadir               = $oldelasticsearch::params::datadir,
+  $plugindir             = $oldelasticsearch::params::plugindir,
+  $plugintool            = $oldelasticsearch::params::plugintool,
   $java_install          = false,
   $java_package          = undef,
   $manage_repo           = false,
@@ -231,15 +231,15 @@ class elasticsearch(
   $logging_file          = undef,
   $logging_config        = undef,
   $logging_template      = undef,
-  $default_logging_level = $elasticsearch::params::default_logging_level,
+  $default_logging_level = $oldelasticsearch::params::default_logging_level,
   $repo_stage            = false,
   $instances             = undef,
   $instances_hiera_merge = false,
   $plugins               = undef,
   $plugins_hiera_merge   = false
-) inherits elasticsearch::params {
+) inherits oldelasticsearch::params {
 
-  anchor {'elasticsearch::begin': }
+  anchor {'oldelasticsearch::begin': }
 
 
   #### Validate parameters
@@ -263,15 +263,15 @@ class elasticsearch(
   # purge conf dir
   validate_bool($purge_configdir)
 
-  if is_array($elasticsearch::params::service_providers) {
+  if is_array($oldelasticsearch::params::service_providers) {
     # Verify the service provider given is in the array
-    if ! ($service_provider in $elasticsearch::params::service_providers) {
+    if ! ($service_provider in $oldelasticsearch::params::service_providers) {
       fail("\"${service_provider}\" is not a valid provider for \"${::operatingsystem}\"")
     }
     $real_service_provider = $service_provider
   } else {
     # There is only one option so simply set it
-    $real_service_provider = $elasticsearch::params::service_providers
+    $real_service_provider = $oldelasticsearch::params::service_providers
   }
 
   if ($package_url != undef and $version != false) {
@@ -316,37 +316,37 @@ class elasticsearch(
   #### Manage actions
 
   # package(s)
-  class { 'elasticsearch::package': }
+  class { 'oldelasticsearch::package': }
 
   # configuration
-  class { 'elasticsearch::config': }
+  class { 'oldelasticsearch::config': }
 
   # Hiera support for instances
   validate_bool($instances_hiera_merge)
 
   if $instances_hiera_merge == true {
-    $x_instances = hiera_hash('elasticsearch::instances', $::elasticsearch::instances)
+    $x_instances = hiera_hash('oldelasticsearch::instances', $::oldelasticsearch::instances)
   } else {
     $x_instances = $instances
   }
 
   if $x_instances {
     validate_hash($x_instances)
-    create_resources('elasticsearch::instance', $x_instances)
+    create_resources('oldelasticsearch::instance', $x_instances)
   }
 
   # Hiera support for plugins
   validate_bool($plugins_hiera_merge)
 
   if $plugins_hiera_merge == true {
-    $x_plugins = hiera_hash('elasticsearch::plugins', $::elasticsearch::plugins)
+    $x_plugins = hiera_hash('oldelasticsearch::plugins', $::oldelasticsearch::plugins)
   } else {
     $x_plugins = $plugins
   }
 
   if $x_plugins {
     validate_hash($x_plugins)
-    create_resources('elasticsearch::plugin', $x_plugins)
+    create_resources('oldelasticsearch::plugin', $x_plugins)
   }
 
 
@@ -358,9 +358,9 @@ class elasticsearch(
     }
 
     # ensure we first install java, the package and then the rest
-    Anchor['elasticsearch::begin']
+    Anchor['oldelasticsearch::begin']
     -> Class['::java']
-    -> Class['elasticsearch::package']
+    -> Class['oldelasticsearch::package']
   }
 
   if ($manage_repo == true) {
@@ -369,13 +369,13 @@ class elasticsearch(
       # use anchor for ordering
 
       # Set up repositories
-      class { 'elasticsearch::repo': }
+      class { 'oldelasticsearch::repo': }
 
       # Ensure that we set up the repositories before trying to install
       # the packages
-      Anchor['elasticsearch::begin']
-      -> Class['elasticsearch::repo']
-      -> Class['elasticsearch::package']
+      Anchor['oldelasticsearch::begin']
+      -> Class['oldelasticsearch::repo']
+      -> Class['oldelasticsearch::package']
 
     } else {
       # use staging for ordering
@@ -384,7 +384,7 @@ class elasticsearch(
         stage { $repo_stage:  before => Stage['main'] }
       }
 
-      class { 'elasticsearch::repo':
+      class { 'oldelasticsearch::repo':
         stage => $repo_stage,
       }
     }
@@ -395,19 +395,19 @@ class elasticsearch(
   if $ensure == 'present' {
 
     # we need the software before configuring it
-    Anchor['elasticsearch::begin']
-    -> Class['elasticsearch::package']
-    -> Class['elasticsearch::config']
-    -> Elasticsearch::Instance <| |>
-    -> Elasticsearch::Template <| |>
+    Anchor['oldelasticsearch::begin']
+    -> Class['oldelasticsearch::package']
+    -> Class['oldelasticsearch::config']
+    -> Oldelasticsearch::Instance <| |>
+    -> Oldelasticsearch::Template <| |>
 
   } else {
 
     # make sure all services are getting stopped before software removal
-    Anchor['elasticsearch::begin']
-    -> Elasticsearch::Instance <| |>
-    -> Class['elasticsearch::config']
-    -> Class['elasticsearch::package']
+    Anchor['oldelasticsearch::begin']
+    -> Oldelasticsearch::Instance <| |>
+    -> Class['oldelasticsearch::config']
+    -> Class['oldelasticsearch::package']
 
   }
 

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -1,4 +1,4 @@
-# == Define: elasticsearch::instance
+# == Define: oldelasticsearch::instance
 #
 #  This define allows you to create or remove an elasticsearch instance
 #
@@ -68,25 +68,25 @@
 #
 # * Richard Pijnenburg <mailto:richard.pijnenburg@elasticsearch.com>
 #
-define elasticsearch::instance(
-  $ensure             = $elasticsearch::ensure,
-  $status             = $elasticsearch::status,
+define oldelasticsearch::instance(
+  $ensure             = $oldelasticsearch::ensure,
+  $status             = $oldelasticsearch::status,
   $config             = undef,
   $configdir          = undef,
   $datadir            = undef,
   $logging_file       = undef,
   $logging_config     = undef,
   $logging_template   = undef,
-  $logging_level      = $elasticsearch::default_logging_level,
+  $logging_level      = $oldelasticsearch::default_logging_level,
   $init_defaults      = undef,
   $init_defaults_file = undef
 ) {
 
-  require elasticsearch::params
+  require oldelasticsearch::params
 
   File {
-    owner => $elasticsearch::elasticsearch_user,
-    group => $elasticsearch::elasticsearch_group,
+    owner => $oldelasticsearch::elasticsearch_user,
+    group => $oldelasticsearch::elasticsearch_group,
   }
 
   Exec {
@@ -99,14 +99,14 @@ define elasticsearch::instance(
     fail("\"${ensure}\" is not a valid ensure parameter value")
   }
 
-  $notify_service = $elasticsearch::restart_on_change ? {
-    true  => Elasticsearch::Service[$name],
+  $notify_service = $oldelasticsearch::restart_on_change ? {
+    true  => Oldelasticsearch::Service[$name],
     false => undef,
   }
 
   # Instance config directory
   if ($configdir == undef) {
-    $instance_configdir = "${elasticsearch::configdir}/${name}"
+    $instance_configdir = "${oldelasticsearch::configdir}/${name}"
   } else {
     $instance_configdir = $configdir
   }
@@ -135,10 +135,10 @@ define elasticsearch::instance(
 
     # String or array for data dir(s)
     if ($datadir == undef) {
-      if (is_array($elasticsearch::datadir)) {
-        $instance_datadir = array_suffix($elasticsearch::datadir, "/${name}")
+      if (is_array($oldelasticsearch::datadir)) {
+        $instance_datadir = array_suffix($oldelasticsearch::datadir, "/${name}")
       } else {
-        $instance_datadir = "${elasticsearch::datadir}/${name}"
+        $instance_datadir = "${oldelasticsearch::datadir}/${name}"
       }
     } else {
       $instance_datadir = $datadir
@@ -148,13 +148,13 @@ define elasticsearch::instance(
     if ($logging_file != undef) {
       $logging_source = $logging_file
       $logging_content = undef
-    } elsif ($elasticsearch::logging_file != undef) {
-      $logging_source = $elasticsearch::logging_file
+    } elsif ($oldelasticsearch::logging_file != undef) {
+      $logging_source = $oldelasticsearch::logging_file
       $logging_content = undef
     } else {
 
-      if(is_hash($elasticsearch::logging_config)) {
-        $main_logging_config = $elasticsearch::logging_config
+      if(is_hash($oldelasticsearch::logging_config)) {
+        $main_logging_config = $oldelasticsearch::logging_config
       } else {
         $main_logging_config = { }
       }
@@ -164,19 +164,19 @@ define elasticsearch::instance(
       } else {
         $instance_logging_config = { }
       }
-      $logging_hash = merge($elasticsearch::params::logging_defaults, $main_logging_config, $instance_logging_config)
+      $logging_hash = merge($oldelasticsearch::params::logging_defaults, $main_logging_config, $instance_logging_config)
       if ($logging_template != undef ) {
         $logging_content = template($logging_template)
-      } elsif ($elasticsearch::logging_template != undef) {
-        $logging_content = template($elasticsearch::logging_template)
+      } elsif ($oldelasticsearch::logging_template != undef) {
+        $logging_content = template($oldelasticsearch::logging_template)
       } else {
         $logging_content = template("${module_name}/etc/elasticsearch/logging.yml.erb")
       }
       $logging_source = undef
     }
 
-    if ($elasticsearch::config != undef) {
-      $main_config = $elasticsearch::config
+    if ($oldelasticsearch::config != undef) {
+      $main_config = $oldelasticsearch::config
     } else {
       $main_config = { }
     }
@@ -202,33 +202,33 @@ define elasticsearch::instance(
     exec { "mkdir_datadir_elasticsearch_${name}":
       command => "mkdir -p ${dirs}",
       creates => $instance_datadir,
-      require => Class['elasticsearch::package'],
+      require => Class['oldelasticsearch::package'],
       before  => Elasticsearch::Service[$name],
     }
 
     file { $instance_datadir:
       ensure  => 'directory',
-      owner   => $elasticsearch::elasticsearch_user,
+      owner   => $oldelasticsearch::elasticsearch_user,
       group   => undef,
       mode    => '0644',
-      require => [ Exec["mkdir_datadir_elasticsearch_${name}"], Class['elasticsearch::package'] ],
-      before  => Elasticsearch::Service[$name],
+      require => [ Exec["mkdir_datadir_elasticsearch_${name}"], Class['oldelasticsearch::package'] ],
+      before  => Oldelasticsearch::Service[$name],
     }
 
     exec { "mkdir_configdir_elasticsearch_${name}":
       command => "mkdir -p ${instance_configdir}",
-      creates => $elasticsearch::configdir,
-      require => Class['elasticsearch::package'],
-      before  => Elasticsearch::Service[$name],
+      creates => $oldelasticsearch::configdir,
+      require => Class['oldelasticsearch::package'],
+      before  => Oldelasticsearch::Service[$name],
     }
 
     file { $instance_configdir:
       ensure  => 'directory',
       mode    => '0644',
-      purge   => $elasticsearch::purge_configdir,
-      force   => $elasticsearch::purge_configdir,
-      require => [ Exec["mkdir_configdir_elasticsearch_${name}"], Class['elasticsearch::package'] ],
-      before  => Elasticsearch::Service[$name],
+      purge   => $oldelasticsearch::purge_configdir,
+      force   => $oldelasticsearch::purge_configdir,
+      require => [ Exec["mkdir_configdir_elasticsearch_${name}"], Class['oldelasticsearch::package'] ],
+      before  => Oldelasticsearch::Service[$name],
     }
 
     file { "${instance_configdir}/logging.yml":
@@ -237,13 +237,13 @@ define elasticsearch::instance(
       source  => $logging_source,
       mode    => '0644',
       notify  => $notify_service,
-      require => Class['elasticsearch::package'],
-      before  => Elasticsearch::Service[$name],
+      require => Class['oldelasticsearch::package'],
+      before  => Oldelasticsearch::Service[$name],
     }
 
     file { "${instance_configdir}/scripts":
       ensure => 'link',
-      target => "${elasticsearch::params::homedir}/scripts",
+      target => "${oldelasticsearch::params::homedir}/scripts",
     }
 
     # build up new config
@@ -255,8 +255,8 @@ define elasticsearch::instance(
       fail ('Only one of $init_defaults and $init_defaults_file should be defined')
     }
 
-    if (is_hash($elasticsearch::init_defaults)) {
-      $global_init_defaults = $elasticsearch::init_defaults
+    if (is_hash($oldelasticsearch::init_defaults)) {
+      $global_init_defaults = $oldelasticsearch::init_defaults
     } else {
       $global_init_defaults = { }
     }
@@ -270,8 +270,8 @@ define elasticsearch::instance(
     }
     $init_defaults_new = merge($global_init_defaults, $instance_init_defaults_main, $instance_init_defaults )
 
-    $user = $elasticsearch::elasticsearch_user
-    $group = $elasticsearch::elasticsearch_group
+    $user = $oldelasticsearch::elasticsearch_user
+    $group = $oldelasticsearch::elasticsearch_group
 
     datacat_fragment { "main_config_${name}":
       target => "${instance_configdir}/elasticsearch.yml",
@@ -281,12 +281,12 @@ define elasticsearch::instance(
     datacat { "${instance_configdir}/elasticsearch.yml":
       template => "${module_name}/etc/elasticsearch/elasticsearch.yml.erb",
       notify   => $notify_service,
-      require  => Class['elasticsearch::package'],
-      owner    => $elasticsearch::elasticsearch_user,
-      group    => $elasticsearch::elasticsearch_group,
+      require  => Class['oldelasticsearch::package'],
+      owner    => $oldelasticsearch::elasticsearch_user,
+      group    => $oldelasticsearch::elasticsearch_group,
     }
 
-    $require_service = Class['elasticsearch::package']
+    $require_service = Class['oldelasticsearch::package']
     $before_service  = undef
 
   } else {
@@ -303,12 +303,12 @@ define elasticsearch::instance(
     $init_defaults_new = {}
   }
 
-  elasticsearch::service { $name:
+  oldelasticsearch::service { $name:
     ensure             => $ensure,
     status             => $status,
     init_defaults      => $init_defaults_new,
     init_defaults_file => $init_defaults_file,
-    init_template      => "${module_name}/etc/init.d/${elasticsearch::params::init_template}",
+    init_template      => "${module_name}/etc/init.d/${oldelasticsearch::params::init_template}",
     require            => $require_service,
     before             => $before_service,
   }

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -203,7 +203,7 @@ define oldelasticsearch::instance(
       command => "mkdir -p ${dirs}",
       creates => $instance_datadir,
       require => Class['oldelasticsearch::package'],
-      before  => Elasticsearch::Service[$name],
+      before  => Oldelasticsearch::Service[$name],
     }
 
     file { $instance_datadir:

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -1,4 +1,4 @@
-# == Class: elasticsearch::package
+# == Class: oldelasticsearch::package
 #
 # This class exists to coordinate all software package management related
 # actions, functionality and logical units in a central place.
@@ -12,7 +12,7 @@
 # === Examples
 #
 # This class may be imported by other classes to use its functionality:
-#   class { 'elasticsearch::package': }
+#   class { 'oldelasticsearch::package': }
 #
 # It is not intended to be used directly by external resources like node
 # definitions or other modules.
@@ -22,7 +22,7 @@
 #
 # * Richard Pijnenburg <mailto:richard.pijnenburg@elasticsearch.com>
 #
-class elasticsearch::package {
+class oldelasticsearch::package {
 
   Exec {
     path      => [ '/bin', '/usr/bin', '/usr/local/bin' ],
@@ -34,12 +34,12 @@ class elasticsearch::package {
   #### Package management
 
   # set params: in operation
-  if $elasticsearch::ensure == 'present' {
+  if $oldelasticsearch::ensure == 'present' {
 
     # Check if we want to install a specific version or not
-    if $elasticsearch::version == false {
+    if $oldelasticsearch::version == false {
 
-      $package_ensure = $elasticsearch::autoupgrade ? {
+      $package_ensure = $oldelasticsearch::autoupgrade ? {
         true  => 'latest',
         false => 'present',
       }
@@ -47,40 +47,40 @@ class elasticsearch::package {
     } else {
 
       # install specific version
-      $package_ensure = $elasticsearch::real_version
+      $package_ensure = $oldelasticsearch::real_version
 
     }
 
     # action
-    if ($elasticsearch::package_url != undef) {
+    if ($oldelasticsearch::package_url != undef) {
 
-      case $elasticsearch::package_provider {
-        'package': { $before = Package[$elasticsearch::package_name]  }
-        default:   { fail("software provider \"${elasticsearch::package_provider}\".") }
+      case $oldelasticsearch::package_provider {
+        'package': { $before = Package[$oldelasticsearch::package_name]  }
+        default:   { fail("software provider \"${oldelasticsearch::package_provider}\".") }
       }
 
-      $package_dir = $elasticsearch::package_dir
+      $package_dir = $oldelasticsearch::package_dir
 
       # Create directory to place the package file
       exec { 'create_package_dir_elasticsearch':
         cwd     => '/',
         path    => ['/usr/bin', '/bin'],
-        command => "mkdir -p ${elasticsearch::package_dir}",
-        creates => $elasticsearch::package_dir,
+        command => "mkdir -p ${oldelasticsearch::package_dir}",
+        creates => $oldelasticsearch::package_dir,
       }
 
       file { $package_dir:
         ensure  => 'directory',
-        purge   => $elasticsearch::purge_package_dir,
-        force   => $elasticsearch::purge_package_dir,
+        purge   => $oldelasticsearch::purge_package_dir,
+        force   => $oldelasticsearch::purge_package_dir,
         backup  => false,
         require => Exec['create_package_dir_elasticsearch'],
       }
 
-      $filenameArray = split($elasticsearch::package_url, '/')
+      $filenameArray = split($oldelasticsearch::package_url, '/')
       $basefilename = $filenameArray[-1]
 
-      $sourceArray = split($elasticsearch::package_url, ':')
+      $sourceArray = split($oldelasticsearch::package_url, ':')
       $protocol_type = $sourceArray[0]
 
       $extArray = split($basefilename, '\.')
@@ -94,7 +94,7 @@ class elasticsearch::package {
 
           file { $pkg_source:
             ensure  => file,
-            source  => $elasticsearch::package_url,
+            source  => $oldelasticsearch::package_url,
             require => File[$package_dir],
             backup  => false,
             before  => $before,
@@ -103,19 +103,19 @@ class elasticsearch::package {
         }
         'ftp', 'https', 'http': {
 
-          if $elasticsearch::proxy_url != undef {
+          if $oldelasticsearch::proxy_url != undef {
             $exec_environment = [
               'use_proxy=yes',
-              "http_proxy=${elasticsearch::proxy_url}",
-              "https_proxy=${elasticsearch::proxy_url}",
+              "http_proxy=${oldelasticsearch::proxy_url}",
+              "https_proxy=${oldelasticsearch::proxy_url}",
             ]
           }
 
           exec { 'download_package_elasticsearch':
-            command     => "${elasticsearch::params::download_tool} ${pkg_source} ${elasticsearch::package_url} 2> /dev/null",
+            command     => "${oldelasticsearch::params::download_tool} ${pkg_source} ${oldelasticsearch::package_url} 2> /dev/null",
             creates     => $pkg_source,
             environment => $exec_environment,
-            timeout     => $elasticsearch::package_dl_timeout,
+            timeout     => $oldelasticsearch::package_dl_timeout,
             require     => File[$package_dir],
             before      => $before,
           }
@@ -138,7 +138,7 @@ class elasticsearch::package {
         }
       }
 
-      if ($elasticsearch::package_provider == 'package') {
+      if ($oldelasticsearch::package_provider == 'package') {
 
         case $ext {
           'deb':   { $pkg_provider = 'dpkg' }
@@ -164,7 +164,7 @@ class elasticsearch::package {
     }
     $package_ensure = 'purged'
 
-    $package_dir = $elasticsearch::package_dir
+    $package_dir = $oldelasticsearch::package_dir
 
     file { $package_dir:
       ensure => 'absent',
@@ -175,16 +175,16 @@ class elasticsearch::package {
 
   }
 
-  if ($elasticsearch::package_provider == 'package') {
+  if ($oldelasticsearch::package_provider == 'package') {
 
-    package { $elasticsearch::package_name:
+    package { $oldelasticsearch::package_name:
       ensure   => $package_ensure,
       source   => $pkg_source,
       provider => $pkg_provider,
     }
 
   } else {
-    fail("\"${elasticsearch::package_provider}\" is not supported")
+    fail("\"${oldelasticsearch::package_provider}\" is not supported")
   }
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,4 +1,4 @@
-# == Class: elasticsearch::params
+# == Class: oldelasticsearch::params
 #
 # This class exists to
 # 1. Declutter the default value assignment for class parameters.
@@ -27,7 +27,7 @@
 #
 # * Richard Pijnenburg <mailto:richard@ispavailability.com>
 #
-class elasticsearch::params {
+class oldelasticsearch::params {
 
   #### Default values for the parameters of the main module class, init.pp
 

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -1,9 +1,9 @@
-# == Define: elasticsearch::plugin
+# == Define: oldelasticsearch::plugin
 #
 # This define allows you to install arbitrary Elasticsearch plugins
 # either by using the default repositories or by specifying an URL
 #
-# All default values are defined in the elasticsearch::params class.
+# All default values are defined in the oldelasticsearch::params class.
 #
 #
 # === Parameters
@@ -67,7 +67,7 @@
 # * Dennis Konert <mailto:dkonert@gmail.com>
 # * Richard Pijnenburg <mailto:richard.pijnenburg@elasticsearch.com>
 #
-define elasticsearch::plugin(
+define oldelasticsearch::plugin(
     $instances,
     $module_dir  = undef,
     $ensure      = 'present',
@@ -77,20 +77,20 @@ define elasticsearch::plugin(
     $proxy_port  = undef,
 ) {
 
-  include elasticsearch
+  include oldelasticsearch
 
   Exec {
     path      => [ '/bin', '/usr/bin', '/usr/local/bin' ],
     cwd       => '/',
-    user      => $elasticsearch::elasticsearch_user,
+    user      => $oldelasticsearch::elasticsearch_user,
     tries     => 6,
     try_sleep => 10,
     timeout   => 600,
   }
 
-  $notify_service = $elasticsearch::restart_on_change ? {
+  $notify_service = $oldelasticsearch::restart_on_change ? {
     false   => undef,
-    default => Elasticsearch::Service[$instances],
+    default => Oldelasticsearch::Service[$instances],
   }
 
   if ($module_dir != undef) {
@@ -101,14 +101,14 @@ define elasticsearch::plugin(
   }
 
   # set proxy by override or parse and use proxy_url from
-  # elasticsearch::proxy_url or use no proxy at all
+  # oldelasticsearch::proxy_url or use no proxy at all
   
   if ($proxy_host != undef and $proxy_port != undef) {
     $proxy = " -DproxyPort=${proxy_port} -DproxyHost=${proxy_host}"
   }
-  elsif ($elasticsearch::proxy_url != undef) {
-    $proxy_host_from_url = regsubst($elasticsearch::proxy_url, '(http|https)://([^:]+)(|:\d+).+', '\2')
-    $proxy_port_from_url = regsubst($elasticsearch::proxy_url, '(?:http|https)://[^:/]+(?::([0-9]+))?(?:/.*)?', '\1')
+  elsif ($oldelasticsearch::proxy_url != undef) {
+    $proxy_host_from_url = regsubst($oldelasticsearch::proxy_url, '(http|https)://([^:]+)(|:\d+).+', '\2')
+    $proxy_port_from_url = regsubst($oldelasticsearch::proxy_url, '(?:http|https)://[^:/]+(?::([0-9]+))?(?:/.*)?', '\1')
     
     # validate parsed values before using them
     if (is_string($proxy_host_from_url) and is_integer($proxy_port_from_url)) {
@@ -138,27 +138,27 @@ define elasticsearch::plugin(
   }
 
   if ($real_url == undef) {
-    $install_cmd = "${elasticsearch::plugintool}${proxy} install ${name}"
+    $install_cmd = "${oldelasticsearch::plugintool}${proxy} install ${name}"
     $exec_rets = [0,]
   } else {
-    $install_cmd = "${elasticsearch::plugintool}${proxy} install ${name} --url ${real_url}"
+    $install_cmd = "${oldelasticsearch::plugintool}${proxy} install ${name} --url ${real_url}"
     $exec_rets = [0,1]
   }
 
   case $ensure {
     'installed', 'present': {
-      $name_file_path = "${elasticsearch::plugindir}/${plugin_dir}/.name"
+      $name_file_path = "${oldelasticsearch::plugindir}/${plugin_dir}/.name"
       exec {"purge_plugin_${plugin_dir}_old":
-        command => "${elasticsearch::plugintool} --remove ${plugin_dir}",
-        onlyif  => "test -e ${elasticsearch::plugindir}/${plugin_dir} && test \"$(cat ${name_file_path})\" != '${name}'",
+        command => "${oldelasticsearch::plugintool} --remove ${plugin_dir}",
+        onlyif  => "test -e ${oldelasticsearch::plugindir}/${plugin_dir} && test \"$(cat ${name_file_path})\" != '${name}'",
         before  => Exec["install_plugin_${name}"],
       }
       exec {"install_plugin_${name}":
         command => $install_cmd,
-        creates => "${elasticsearch::plugindir}/${plugin_dir}",
+        creates => "${oldelasticsearch::plugindir}/${plugin_dir}",
         returns => $exec_rets,
         notify  => $notify_service,
-        require => File[$elasticsearch::plugindir],
+        require => File[$oldelasticsearch::plugindir],
       }
       file {$name_file_path:
         ensure  => file,
@@ -168,8 +168,8 @@ define elasticsearch::plugin(
     }
     'absent': {
       exec {"remove_plugin_${name}":
-        command => "${elasticsearch::plugintool} --remove ${plugin_dir}",
-        onlyif  => "test -d ${elasticsearch::plugindir}/${plugin_dir}",
+        command => "${oldelasticsearch::plugintool} --remove ${plugin_dir}",
+        onlyif  => "test -d ${oldelasticsearch::plugindir}/${plugin_dir}",
         notify  => $notify_service,
       }
     }

--- a/manifests/python.pp
+++ b/manifests/python.pp
@@ -1,4 +1,4 @@
-# == Define: elasticsearch::python
+# == Define: oldelasticsearch::python
 #
 # there are many python bindings for elasticsearch. This provides all
 # the ones we know about http://www.elasticsearch.org/guide/clients/
@@ -21,13 +21,13 @@
 #
 # === Examples
 #
-# elasticsearch::python { 'pyes':; }
+# oldelasticsearch::python { 'pyes':; }
 #
 # === Authors
 #
 # * Richard Pijnenburg <mailto:richard.pijnenburg@elasticsearch.com>
 #
-define elasticsearch::python (
+define oldelasticsearch::python (
   $ensure = 'present'
 ) {
 

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,4 +1,4 @@
-# == Class: elasticsearch::repo
+# == Class: oldelasticsearch::repo
 #
 # This class exists to install and manage yum and apt repositories
 # that contain elasticsearch official elasticsearch packages
@@ -12,7 +12,7 @@
 # === Examples
 #
 # This class may be imported by other classes to use its functionality:
-#   class { 'elasticsearch::repo': }
+#   class { 'oldelasticsearch::repo': }
 #
 # It is not intended to be used directly by external resources like node
 # definitions or other modules.
@@ -23,7 +23,7 @@
 # * Phil Fenstermacher <mailto:phillip.fenstermacher@gmail.com>
 # * Richard Pijnenburg <mailto:richard.pijnenburg@elasticsearch.com>
 #
-class elasticsearch::repo {
+class oldelasticsearch::repo {
 
   Exec {
     path      => [ '/bin', '/usr/bin', '/usr/local/bin' ],
@@ -37,7 +37,7 @@ class elasticsearch::repo {
       }
 
       apt::source { 'elasticsearch':
-        location    => "http://packages.elastic.co/elasticsearch/${elasticsearch::repo_version}/debian",
+        location    => "http://packages.elastic.co/elasticsearch/${oldelasticsearch::repo_version}/debian",
         release     => 'stable',
         repos       => 'main',
         key         => 'D88E42B4',
@@ -48,7 +48,7 @@ class elasticsearch::repo {
     'RedHat', 'Linux': {
       yumrepo { 'elasticsearch':
         descr    => 'elasticsearch repo',
-        baseurl  => "http://packages.elastic.co/elasticsearch/${elasticsearch::repo_version}/centos",
+        baseurl  => "http://packages.elastic.co/elasticsearch/${oldelasticsearch::repo_version}/centos",
         gpgcheck => 1,
         gpgkey   => 'http://packages.elastic.co/GPG-KEY-elasticsearch',
         enabled  => 1,
@@ -62,7 +62,7 @@ class elasticsearch::repo {
       }
 
       zypprepo { 'elasticsearch':
-        baseurl     => "http://packages.elastic.co/elasticsearch/${elasticsearch::repo_version}/centos",
+        baseurl     => "http://packages.elastic.co/elasticsearch/${oldelasticsearch::repo_version}/centos",
         enabled     => 1,
         autorefresh => 1,
         name        => 'elasticsearch',
@@ -77,23 +77,23 @@ class elasticsearch::repo {
   }
 
   # Package pinning
-  if ($elasticsearch::package_pin == true and $elasticsearch::version != false) {
+  if ($oldelasticsearch::package_pin == true and $oldelasticsearch::version != false) {
     case $::osfamily {
       'Debian': {
         if !defined(Class['apt']) {
           class { 'apt': }
         }
 
-        apt::pin { $elasticsearch::package_name:
+        apt::pin { $oldelasticsearch::package_name:
           ensure   => 'present',
-          packages => $elasticsearch::package_name,
-          version  => $elasticsearch::real_version,
+          packages => $oldelasticsearch::package_name,
+          version  => $oldelasticsearch::real_version,
           priority => 1000,
         }
       }
       'RedHat', 'Linux': {
 
-        yum::versionlock { "0:elasticsearch-${elasticsearch::real_version}.noarch":
+        yum::versionlock { "0:elasticsearch-${oldelasticsearch::real_version}.noarch":
           ensure => 'present',
         }
       }

--- a/manifests/ruby.pp
+++ b/manifests/ruby.pp
@@ -1,4 +1,4 @@
-# == Define: elasticsearch::ruby
+# == Define: oldelasticsearch::ruby
 #
 # there are many ruby bindings for elasticsearch. This provides all
 # the ones we know about http://www.elasticsearch.org/guide/clients/
@@ -21,13 +21,13 @@
 #
 # === Examples
 #
-# elasticsearch::ruby { 'elasticsearch':; }
+# oldelasticsearch::ruby { 'elasticsearch':; }
 #
 # === Authors
 #
 # * Richard Pijnenburg <mailto:richard@ispavailability.com>
 #
-define elasticsearch::ruby (
+define oldelasticsearch::ruby (
   $ensure = 'present'
 ) {
 

--- a/manifests/script.pp
+++ b/manifests/script.pp
@@ -1,4 +1,4 @@
-# == Define: elasticsearch::script
+# == Define: oldelasticsearch::script
 #
 #  This define allows you to insert, update or delete scripts that are used within Elasticsearch
 #
@@ -28,12 +28,12 @@
 #
 # * Richard Pijnenburg <mailto:richard.pijnenburg@elasticsearch.com>
 #
-define elasticsearch::script(
+define oldelasticsearch::script(
   $source,
   $ensure  = 'present',
 ) {
 
-  require elasticsearch
+  require oldelasticsearch
 
   # ensure
   if ! ($ensure in [ 'present', 'absent' ]) {
@@ -45,11 +45,11 @@ define elasticsearch::script(
   $filenameArray = split($source, '/')
   $basefilename = $filenameArray[-1]
 
-  file { "${elasticsearch::params::homedir}/scripts/${basefilename}":
+  file { "${oldelasticsearch::params::homedir}/scripts/${basefilename}":
     ensure => $ensure,
     source => $source,
-    owner  => $elasticsearch::elasticsearch_user,
-    group  => $elasticsearch::elasticsearch_group,
+    owner  => $oldelasticsearch::elasticsearch_user,
+    group  => $oldelasticsearch::elasticsearch_group,
     mode   => '0644',
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,4 +1,4 @@
-# == Class: elasticsearch::service
+# == Class: oldelasticsearch::service
 #
 # This class exists to coordinate all service management related actions,
 # functionality and logical units in a central place.
@@ -54,18 +54,18 @@
 #
 # * Richard Pijnenburg <mailto:richard.pijnenburg@elasticsearch.com>
 #
-define elasticsearch::service(
-  $ensure             = $elasticsearch::ensure,
-  $status             = $elasticsearch::status,
+define oldelasticsearch::service(
+  $ensure             = $oldelasticsearch::ensure,
+  $status             = $oldelasticsearch::status,
   $init_defaults_file = undef,
   $init_defaults      = undef,
   $init_template      = undef,
 ) {
 
-  case $elasticsearch::real_service_provider {
+  case $oldelasticsearch::real_service_provider {
 
     'init': {
-      elasticsearch::service::init { $name:
+      oldelasticsearch::service::init { $name:
         ensure             => $ensure,
         status             => $status,
         init_defaults_file => $init_defaults_file,
@@ -74,7 +74,7 @@ define elasticsearch::service(
       }
     }
     'systemd': {
-      elasticsearch::service::systemd { $name:
+      oldelasticsearch::service::systemd { $name:
         ensure             => $ensure,
         status             => $status,
         init_defaults_file => $init_defaults_file,
@@ -83,7 +83,7 @@ define elasticsearch::service(
       }
     }
     default: {
-      fail("Unknown service provider ${elasticsearch::real_service_provider}")
+      fail("Unknown service provider ${oldelasticsearch::real_service_provider}")
     }
 
   }

--- a/manifests/service/init.pp
+++ b/manifests/service/init.pp
@@ -1,4 +1,4 @@
-# == Define: elasticsearch::service::init
+# == Define: oldelasticsearch::service::init
 #
 # This class exists to coordinate all service management related actions,
 # functionality and logical units in a central place.
@@ -54,9 +54,9 @@
 #
 # * Richard Pijnenburg <mailto:richard.pijnenburg@elasticsearch.com>
 #
-define elasticsearch::service::init(
-  $ensure             = $elasticsearch::ensure,
-  $status             = $elasticsearch::status,
+define oldelasticsearch::service::init(
+  $ensure             = $oldelasticsearch::ensure,
+  $status             = $oldelasticsearch::status,
   $init_defaults_file = undef,
   $init_defaults      = undef,
   $init_template      = undef,
@@ -107,7 +107,7 @@ define elasticsearch::service::init(
 
   }
 
-  $notify_service = $elasticsearch::restart_on_change ? {
+  $notify_service = $oldelasticsearch::restart_on_change ? {
     true  => Service["elasticsearch-instance-${name}"],
     false => undef,
   }
@@ -117,7 +117,7 @@ define elasticsearch::service::init(
 
     # defaults file content. Either from a hash or file
     if ($init_defaults_file != undef) {
-      file { "${elasticsearch::params::defaults_location}/elasticsearch-${name}":
+      file { "${oldelasticsearch::params::defaults_location}/elasticsearch-${name}":
         ensure => $ensure,
         source => $init_defaults_file,
         owner  => 'root',
@@ -130,16 +130,16 @@ define elasticsearch::service::init(
     } elsif ($init_defaults != undef and is_hash($init_defaults) ) {
 
       if(has_key($init_defaults, 'ES_USER')) {
-        if($init_defaults['ES_USER'] != $elasticsearch::elasticsearch_user) {
+        if($init_defaults['ES_USER'] != $oldelasticsearch::elasticsearch_user) {
           fail('Found ES_USER setting for init_defaults but is not same as elasticsearch_user setting. Please use elasticsearch_user setting.')
         }
       }
 
-      $init_defaults_pre_hash = { 'ES_USER' => $elasticsearch::elasticsearch_user, 'ES_GROUP' => $elasticsearch::elasticsearch_group, 'MAX_OPEN_FILES' => '65535' }
+      $init_defaults_pre_hash = { 'ES_USER' => $oldelasticsearch::elasticsearch_user, 'ES_GROUP' => $oldelasticsearch::elasticsearch_group, 'MAX_OPEN_FILES' => '65535' }
       $new_init_defaults = merge($init_defaults_pre_hash, $init_defaults)
 
       augeas { "defaults_${name}":
-        incl    => "${elasticsearch::params::defaults_location}/elasticsearch-${name}",
+        incl    => "${oldelasticsearch::params::defaults_location}/elasticsearch-${name}",
         lens    => 'Shellvars.lns',
         changes => template("${module_name}/etc/sysconfig/defaults.erb"),
         before  => Service["elasticsearch-instance-${name}"],
@@ -170,7 +170,7 @@ define elasticsearch::service::init(
       subscribe => Service["elasticsearch-instance-${name}"],
     }
 
-    file { "${elasticsearch::params::defaults_location}/elasticsearch-${name}":
+    file { "${oldelasticsearch::params::defaults_location}/elasticsearch-${name}":
       ensure    => 'absent',
       subscribe => Service["elasticsearch-${$name}"],
     }
@@ -185,9 +185,9 @@ define elasticsearch::service::init(
       ensure     => $service_ensure,
       enable     => $service_enable,
       name       => "elasticsearch-${name}",
-      hasstatus  => $elasticsearch::params::service_hasstatus,
-      hasrestart => $elasticsearch::params::service_hasrestart,
-      pattern    => $elasticsearch::params::service_pattern,
+      hasstatus  => $oldelasticsearch::params::service_hasstatus,
+      hasrestart => $oldelasticsearch::params::service_hasrestart,
+      pattern    => $oldelasticsearch::params::service_pattern,
     }
 
   }

--- a/manifests/service/systemd.pp
+++ b/manifests/service/systemd.pp
@@ -1,4 +1,4 @@
-# == Define: elasticsearch::service::systemd
+# == Define: oldelasticsearch::service::systemd
 #
 # This define exists to coordinate all service management related actions,
 # functionality and logical units in a central place.
@@ -54,9 +54,9 @@
 #
 # * Richard Pijnenburg <mailto:richard.pijnenburg@elasticsearch.com>
 #
-define elasticsearch::service::systemd(
-  $ensure             = $elasticsearch::ensure,
-  $status             = $elasticsearch::status,
+define oldelasticsearch::service::systemd(
+  $ensure             = $oldelasticsearch::ensure,
+  $status             = $oldelasticsearch::status,
   $init_defaults_file = undef,
   $init_defaults      = undef,
   $init_template      = undef,
@@ -103,7 +103,7 @@ define elasticsearch::service::systemd(
     $service_enable = false
   }
 
-  $notify_service = $elasticsearch::restart_on_change ? {
+  $notify_service = $oldelasticsearch::restart_on_change ? {
     true  => [ Exec["systemd_reload_${name}"], Service["elasticsearch-instance-${name}"] ],
     false => Exec["systemd_reload_${name}"]
   }
@@ -112,7 +112,7 @@ define elasticsearch::service::systemd(
 
     # defaults file content. Either from a hash or file
     if ($init_defaults_file != undef) {
-      file { "${elasticsearch::params::defaults_location}/elasticsearch-${name}":
+      file { "${oldelasticsearch::params::defaults_location}/elasticsearch-${name}":
         ensure => $ensure,
         source => $init_defaults_file,
         owner  => 'root',
@@ -126,16 +126,16 @@ define elasticsearch::service::systemd(
       if ($init_defaults != undef and is_hash($init_defaults) ) {
 
         if(has_key($init_defaults, 'ES_USER')) {
-          if($init_defaults['ES_USER'] != $elasticsearch::elasticsearch_user) {
+          if($init_defaults['ES_USER'] != $oldelasticsearch::elasticsearch_user) {
             fail('Found ES_USER setting for init_defaults but is not same as elasticsearch_user setting. Please use elasticsearch_user setting.')
           }
         }
       }
-      $init_defaults_pre_hash = { 'ES_USER' => $elasticsearch::elasticsearch_user, 'ES_GROUP' => $elasticsearch::elasticsearch_group, 'MAX_OPEN_FILES' => '65535' }
+      $init_defaults_pre_hash = { 'ES_USER' => $oldelasticsearch::elasticsearch_user, 'ES_GROUP' => $oldelasticsearch::elasticsearch_group, 'MAX_OPEN_FILES' => '65535' }
       $new_init_defaults = merge($init_defaults_pre_hash, $init_defaults)
 
       augeas { "defaults_${name}":
-        incl    => "${elasticsearch::params::defaults_location}/elasticsearch-${name}",
+        incl    => "${oldelasticsearch::params::defaults_location}/elasticsearch-${name}",
         lens    => 'Shellvars.lns',
         changes => template("${module_name}/etc/sysconfig/defaults.erb"),
         before  => Service["elasticsearch-instance-${name}"],
@@ -146,10 +146,10 @@ define elasticsearch::service::systemd(
     # init file from template
     if ($init_template != undef) {
 
-      $user              = $elasticsearch::elasticsearch_user
-      $group             = $elasticsearch::elasticsearch_group
-      $pid_dir           = $elasticsearch::pid_dir
-      $defaults_location = $elasticsearch::defaults_location
+      $user              = $oldelasticsearch::elasticsearch_user
+      $group             = $oldelasticsearch::elasticsearch_group
+      $pid_dir           = $oldelasticsearch::pid_dir
+      $defaults_location = $oldelasticsearch::defaults_location
 
       if ($new_init_defaults != undef and is_hash($new_init_defaults) and has_key($new_init_defaults, 'MAX_OPEN_FILES')) {
         $nofile = $new_init_defaults['MAX_OPEN_FILES']
@@ -182,7 +182,7 @@ define elasticsearch::service::systemd(
       notify    => Exec["systemd_reload_${name}"],
     }
 
-    file { "${elasticsearch::params::defaults_location}/elasticsearch-${name}":
+    file { "${oldelasticsearch::params::defaults_location}/elasticsearch-${name}":
       ensure    => 'absent',
       subscribe => Service["elasticsearch-instance-${name}"],
       notify    => Exec["systemd_reload_${name}"],
@@ -204,9 +204,9 @@ define elasticsearch::service::systemd(
       ensure     => $service_ensure,
       enable     => $service_enable,
       name       => "elasticsearch-${name}.service",
-      hasstatus  => $elasticsearch::params::service_hasstatus,
-      hasrestart => $elasticsearch::params::service_hasrestart,
-      pattern    => $elasticsearch::params::service_pattern,
+      hasstatus  => $oldelasticsearch::params::service_hasstatus,
+      hasrestart => $oldelasticsearch::params::service_hasrestart,
+      pattern    => $oldelasticsearch::params::service_pattern,
       provider   => 'systemd',
       require    => $service_require,
     }

--- a/manifests/snapshot.pp
+++ b/manifests/snapshot.pp
@@ -1,4 +1,4 @@
-# == Class: elasticsearch::snapshot
+# == Class: oldelasticsearch::snapshot
 #
 # This class is able to activate snapshots for elasticsearch
 #
@@ -31,21 +31,21 @@
 #       script_path => '/root'
 #     }
 #
-class elasticsearch::snapshot(
+class oldelasticsearch::snapshot(
   $name             = undef,
-  $type             = $elasticsearch::params::snapshot_type,
+  $type             = $oldelasticsearch::params::snapshot_type,
   $location         = undef,
   $bucket           = undef,
   $region           = undef,
   $base_path        = undef,
-  $script_path      = $elasticsearch::params::snapshot_script_path,
+  $script_path      = $oldelasticsearch::params::snapshot_script_path,
   $cronjob          = false,
-  $cron_starthour   = $elasticsearch::params::cron_starthour,
-  $cron_startminute = $elasticsearch::params::cron_startminute,
-  $snapshot_age     = $elasticsearch::params::snapshot_age,
+  $cron_starthour   = $oldelasticsearch::params::cron_starthour,
+  $cron_startminute = $oldelasticsearch::params::cron_startminute,
+  $snapshot_age     = $oldelasticsearch::params::snapshot_age,
   ){
 
-  require elasticsearch::params
+  require oldelasticsearch::params
 
   if ($type == 'fs') {
     $settings = "{\"location\": \"${location}\",\"compress\": true}"
@@ -69,7 +69,7 @@ class elasticsearch::snapshot(
   file {
     "${script_path}/elasticsearch_backup.py":
       ensure => file,
-      source => 'puppet:///modules/elasticsearch/usr/local/bin/elasticsearch_backup.py',
+      source => "puppet:///modules/${module_name}/usr/local/bin/elasticsearch_backup.py",
       owner => root,
       group => root,
       mode => '0775';
@@ -89,7 +89,7 @@ class elasticsearch::snapshot(
     file {
       '/etc/cron.d/elasticsearch':
         ensure  => file,
-        content => template('elasticsearch/etc/cron.d/elasticsearch.erb'),
+        content => template("${module_name}/etc/cron.d/elasticsearch.erb"),
         owner   => root,
         group   => root,
         mode    => '0644';

--- a/manifests/template.pp
+++ b/manifests/template.pp
@@ -1,4 +1,4 @@
-# == Define: elasticsearch::template
+# == Define: oldelasticsearch::template
 #
 #  This define allows you to insert, update or delete templates that are used within Elasticsearch for the indexes
 #
@@ -46,7 +46,7 @@
 #
 # * Richard Pijnenburg <mailto:richard.pijnenburg@elasticsearch.com>
 #
-define elasticsearch::template(
+define oldelasticsearch::template(
   $ensure  = 'present',
   $file    = undef,
   $content = undef,
@@ -54,7 +54,7 @@ define elasticsearch::template(
   $port    = 9200
 ) {
 
-  require elasticsearch
+  require oldelasticsearch
 
   # ensure
   if ! ($ensure in [ 'present', 'absent' ]) {
@@ -106,10 +106,10 @@ define elasticsearch::template(
   if ($ensure == 'absent') {
 
     # delete the template file on disk and then on the server
-    file { "${elasticsearch::params::homedir}/templates_import/elasticsearch-template-${name}.json":
+    file { "${oldelasticsearch::params::homedir}/templates_import/elasticsearch-template-${name}.json":
       ensure  => 'absent',
       notify  => Exec[ "delete_template_${name}" ],
-      require => File[ "${elasticsearch::params::homedir}/templates_import" ],
+      require => File[ "${oldelasticsearch::params::homedir}/templates_import" ],
     }
   }
 
@@ -117,24 +117,24 @@ define elasticsearch::template(
 
     if $content == undef {
       # place the template file using the file source
-      file { "${elasticsearch::params::homedir}/templates_import/elasticsearch-template-${name}.json":
+      file { "${oldelasticsearch::params::homedir}/templates_import/elasticsearch-template-${name}.json":
         ensure  => file,
         source  => $file,
         notify  => Exec[ "delete_template_${name}" ],
-        require => File[ "${elasticsearch::params::homedir}/templates_import" ],
+        require => File[ "${oldelasticsearch::params::homedir}/templates_import" ],
       }
     } else {
       # place the template file using content
-      file { "${elasticsearch::params::homedir}/templates_import/elasticsearch-template-${name}.json":
+      file { "${oldelasticsearch::params::homedir}/templates_import/elasticsearch-template-${name}.json":
         ensure  => file,
         content => $content,
         notify  => Exec[ "delete_template_${name}" ],
-        require => File[ "${elasticsearch::params::homedir}/templates_import" ],
+        require => File[ "${oldelasticsearch::params::homedir}/templates_import" ],
       }
     }
 
     exec { "insert_template_${name}":
-      command     => "curl -sL -w \"%{http_code}\\n\" -XPUT ${es_url} -d @${elasticsearch::params::homedir}/templates_import/elasticsearch-template-${name}.json -o /dev/null | egrep \"(200|201)\" > /dev/null",
+      command     => "curl -sL -w \"%{http_code}\\n\" -XPUT ${es_url} -d @${oldelasticsearch::params::homedir}/templates_import/elasticsearch-template-${name}.json -o /dev/null | egrep \"(200|201)\" > /dev/null",
       unless      => "test $(curl -s '${es_url}?pretty=true' | wc -l) -gt 1",
       refreshonly => true,
       loglevel    => 'debug',

--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
-  "name": "elasticsearch-elasticsearch",
+  "name": "skyscrapers-oldelasticsearch",
   "version": "0.9.9",
-  "source": "https://github.com/elastic/puppet-elasticsearch",
+  "source": "https://github.com/skyscrapers/puppet-elasticsearch",
   "author": "elasticsearch",
   "license": "Apache-2.0",
   "summary": "Module for managing and configuring Elasticsearch nodes",


### PR DESCRIPTION
This branch *will and may not* be merged into master. It only exists temporarily to support the refresh to the latest upstream of the module.

Just for validation if the rename of the module to `oldelasticsearch` was done correctly. The tests have not been renamed as this code is only used temporarily while the whole refresh process to the new upstream of `elasticsearch` takes place.