### PR TITLE
Use the puppet cron resource and make sure it's removed if not wanted

### DIFF
--- a/templates/etc/cron.d/elasticsearch.erb
+++ b/templates/etc/cron.d/elasticsearch.erb
@@ -1,1 +1,0 @@
-<%= @cron_startminute %> <%= @cron_starthour %> * * * root <%= @script_path %>/elasticsearch_backup.py -n <%= @name %> -a <%= @snapshot_age %>


### PR DESCRIPTION
Maybe it's a good idea to contribute back this snapshot class to upstream.