### PR TITLE
Env var inside an env var is not working in systemd

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -446,7 +446,7 @@ define elasticsearch::instance(
       $instance_init_defaults = { }
     }
     $init_defaults_new = merge(
-      { 'DATA_DIR'  => '/usr/share/elasticsearch/data' },
+      { 'DATA_DIR'  => "${instance_init_defaults_main['ES_HOME']}/data" },
       $global_init_defaults,
       $instance_init_defaults_main,
       $instance_init_defaults

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -446,7 +446,7 @@ define elasticsearch::instance(
       $instance_init_defaults = { }
     }
     $init_defaults_new = merge(
-      { 'DATA_DIR'  => '$ES_HOME/data' },
+      { 'DATA_DIR'  => '/usr/share/elasticsearch/data' },
       $global_init_defaults,
       $instance_init_defaults_main,
       $instance_init_defaults


### PR DESCRIPTION
With systemd we ran into the following problem:

```
[2017-06-12T10:30:18,373][WARN ][o.e.b.ElasticsearchUncaughtExceptionHandler] [elasticsearch01.compant-staging.skyscrape.rs] uncaught exception in thread [main]
org.elasticsearch.bootstrap.StartupException: java.lang.IllegalStateException: Unable to access 'default.path.data' ($ES_HOME/data)
        at org.elasticsearch.bootstrap.Elasticsearch.init(Elasticsearch.java:127) ~[elasticsearch-5.3.3.jar:5.3.3]
        at org.elasticsearch.bootstrap.Elasticsearch.execute(Elasticsearch.java:114) ~[elasticsearch-5.3.3.jar:5.3.3]
        at org.elasticsearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:58) ~[elasticsearch-5.3.3.jar:5.3.3]
        at org.elasticsearch.cli.Command.mainWithoutErrorHandling(Command.java:122) ~[elasticsearch-5.3.3.jar:5.3.3]
        at org.elasticsearch.cli.Command.main(Command.java:88) ~[elasticsearch-5.3.3.jar:5.3.3]
        at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:91) ~[elasticsearch-5.3.3.jar:5.3.3]
        at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:84) ~[elasticsearch-5.3.3.jar:5.3.3]
Caused by: java.lang.IllegalStateException: Unable to access 'default.path.data' ($ES_HOME/data)
        at org.elasticsearch.bootstrap.Security.addPath(Security.java:397) ~[elasticsearch-5.3.3.jar:5.3.3]
        at org.elasticsearch.bootstrap.Security.addFilePermissions(Security.java:276) ~[elasticsearch-5.3.3.jar:5.3.3]
        at org.elasticsearch.bootstrap.Security.createPermissions(Security.java:208) ~[elasticsearch-5.3.3.jar:5.3.3]
        at org.elasticsearch.bootstrap.Security.configure(Security.java:114) ~[elasticsearch-5.3.3.jar:5.3.3]
        at org.elasticsearch.bootstrap.Bootstrap.setup(Bootstrap.java:237) ~[elasticsearch-5.3.3.jar:5.3.3]
        at org.elasticsearch.bootstrap.Bootstrap.init(Bootstrap.java:360) ~[elasticsearch-5.3.3.jar:5.3.3]
        at org.elasticsearch.bootstrap.Elasticsearch.init(Elasticsearch.java:123) ~[elasticsearch-5.3.3.jar:5.3.3]
        ... 6 more
Caused by: java.nio.file.AccessDeniedException: /$ES_HOME
        at sun.nio.fs.UnixException.translateToIOException(UnixException.java:84) ~[?:1.8.0_131]
        at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102) ~[?:1.8.0_131]
        at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107) ~[?:1.8.0_131]
        at sun.nio.fs.UnixFileSystemProvider.createDirectory(UnixFileSystemProvider.java:384) ~[?:1.8.0_131]
        at java.nio.file.Files.createDirectory(Files.java:674) ~[?:1.8.0_131]
        at java.nio.file.Files.createAndCheckIsDirectory(Files.java:781) ~[?:1.8.0_131]
        at java.nio.file.Files.createDirectories(Files.java:767) ~[?:1.8.0_131]
        at org.elasticsearch.bootstrap.Security.ensureDirectoryExists(Security.java:439) ~[elasticsearch-5.3.3.jar:5.3.3]
        at org.elasticsearch.bootstrap.Security.addPath(Security.java:395) ~[elasticsearch-5.3.3.jar:5.3.3]
        at org.elasticsearch.bootstrap.Security.addFilePermissions(Security.java:276) ~[elasticsearch-5.3.3.jar:5.3.3]
        at org.elasticsearch.bootstrap.Security.createPermissions(Security.java:208) ~[elasticsearch-5.3.3.jar:5.3.3]
        at org.elasticsearch.bootstrap.Security.configure(Security.java:114) ~[elasticsearch-5.3.3.jar:5.3.3]
        at org.elasticsearch.bootstrap.Bootstrap.setup(Bootstrap.java:237) ~[elasticsearch-5.3.3.jar:5.3.3]
        at org.elasticsearch.bootstrap.Bootstrap.init(Bootstrap.java:360) ~[elasticsearch-5.3.3.jar:5.3.3]
        at org.elasticsearch.bootstrap.Elasticsearch.init(Elasticsearch.java:123) ~[elasticsearch-5.3.3.jar:5.3.3]
        ... 6 more
```

After investigation I found that an environment variable inside an environment variable is not working. Setting the value there as well works. The value is a copy of Line#439 of that file. Upstream there are a lot of changes and we should update our module to the latest version. In there is also a major overhaul of systemd but atm that would have taken too much time to get it running.